### PR TITLE
Update tests for galaxy support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ deploy:
   user: danrue
 python: 3.5
 env:
-  - TOXENV=py35
-  - TOXENV=py34
-  - TOXENV=py33
+#  - TOXENV=py35
+#  - TOXENV=py34
+#  - TOXENV=py33
   - TOXENV=py27
   - TOXENV=py26
   - TOXENV=pypy

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,11 @@ setup(
     package_dir={'galaxy_updater':
                  'galaxy_updater'},
     include_package_data=True,
-    install_requires=['ruamel.yaml', 'future', 'ansible'],
+    install_requires=[
+                      'ruamel.yaml',
+                      'future',
+                      'ansible>=2',
+                     ],
     license="BSD",
     keywords='ansible-galaxy ansible galaxy requirements.yml',
     classifiers=[
@@ -38,13 +42,12 @@ setup(
         "Programming Language :: Python :: 2",
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
     ],
     test_suite='tests',
-    tests_require=['pytest'],
+    tests_require=[
+                   'pytest',
+                   'ansible>=2.0',
+                  ],
 
     entry_points={
         'console_scripts': [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py269, py2711, py336, py344, py351
+envlist = py269, py2711
 
 [testenv]
 setenv =


### PR DESCRIPTION
- Drop support for python 3 (since ansible doesn't, yet)
- Require ansible 2, for the galaxy import
