### PR TITLE
Remove ansible/galaxy dependencies

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,4 +10,4 @@ Development Lead
 Contributors
 ------------
 
-None yet. Why not be the first?
+* Stanislav Bogatyrev <realloc@realloc.spb.ru>

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,11 +1,16 @@
 =======
 History
 =======
+
+0.3.0 (2016-09-01)
+------------------
+
+* Add support for galaxy style roles (user.rolename)
+
 0.2.0 (2016-04-07)
 ------------------
 
 * Add --inline, --yolo, --version
-
 
 0.1.3 (2016-01-15)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,9 @@ Given an example ansible-galaxy role file::
     - src: https://github.com/geerlingguy/ansible-role-php.git 
       name: ansible-role-php
       version: 1.5.0
+    - src: yatesr.timezone
+    - src: carlosbuenosvinos.ansistrano-deploy
+      version: 1.4.0
 
 Find and print the latest version of each role listed in an ansible-galaxy role
 file::
@@ -39,6 +42,8 @@ file::
     ansible-role-mysql: 1.9.0 -> 1.9.1
     ansible-role-apache: None -> 1.5.0
     ansible-role-php: 1.5.0 -> 1.7.3
+    yatesr.timezone: None -> 1.0.0
+    carlosbuenosvinos.ansistrano-deploy: 1.4.0 -> 1.10.0
 
 Update the sample_requirements.yml file in place::
 
@@ -46,10 +51,12 @@ Update the sample_requirements.yml file in place::
     ansible-role-mysql: 1.9.0 -> 1.9.1
     ansible-role-apache: None -> 1.5.0
     ansible-role-php: 1.5.0 -> 1.7.3
+    yatesr.timezone: None -> 1.0.0
+    carlosbuenosvinos.ansistrano-deploy: 1.4.0 -> 1.10.0
 
 Use --yolo to leave unpinned dependencies unpinned::
 
-    $ galaxy-updater --inline sample_requirements.yml 
+    $ galaxy-updater --yolo sample_requirements.yml 
     ansible-role-mysql: 1.9.0 -> 1.9.1
     ansible-role-php: 1.5.0 -> 1.7.3
-
+    carlosbuenosvinos.ansistrano-deploy: 1.4.0 -> 1.10.0

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,10 @@ setup(
     package_dir={'galaxy_updater':
                  'galaxy_updater'},
     include_package_data=True,
-    install_requires=['ruamel.yaml', 'future', 'ansible'],
+    install_requires=[
+                      'ruamel.yaml==0.11.15', # Last py26 version
+                      'future',
+                      'requests'],
     license="BSD",
     keywords='ansible-galaxy ansible galaxy requirements.yml',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(
     install_requires=[
                       'ruamel.yaml==0.11.15', # Last py26 version
                       'future',
-                      'requests'],
+                      'requests'
+                     ],
     license="BSD",
     keywords='ansible-galaxy ansible galaxy requirements.yml',
     classifiers=[

--- a/tests/test_files/sample_requirements.yml
+++ b/tests/test_files/sample_requirements.yml
@@ -10,3 +10,7 @@
 - src: https://github.com/geerlingguy/ansible-role-php.git 
   name: ansible-role-php
   version: 1.5.0
+- src: yatesr.timezone
+- src: carlosbuenosvinos.ansistrano-deploy
+  version: 1.4.0
+

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,5 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/galaxy_updater
 deps =
   pytest
-  ansible
 commands = py.test
 


### PR DESCRIPTION
If we bring in ansible as a dependency, it gets hard to support python
3+ as well as ansible<2. By implementing the galaxy role resolution
ourselves, it simplifies the code and allows us to remain agnostic in
terms of python and ansible versions.
